### PR TITLE
Fix closedAt test in finalize.

### DIFF
--- a/src/main/java/com/atlascopco/hunspell/Hunspell.java
+++ b/src/main/java/com/atlascopco/hunspell/Hunspell.java
@@ -422,7 +422,7 @@ public class Hunspell implements Closeable {
 	
 	@Override
 	protected void finalize() throws Throwable {
-		if (this.closedAt!=null){
+		if (this.closedAt == null){
 			this.close();
 			System.err.println("Hunspell instance was not closed!");
 		}


### PR DESCRIPTION
I noticed this because I was seeing the message about Hunspell being
closed even when I had cloased it, but it would be more of a problem
when close wasn't called and the finalize method didn't catch it.