### PR TITLE
Allow to use hunspell-bridj inside an OSGi bundle.

### DIFF
--- a/src/main/java/com/atlascopco/hunspell/HunspellLibrary.java
+++ b/src/main/java/com/atlascopco/hunspell/HunspellLibrary.java
@@ -21,7 +21,7 @@ import org.bridj.ann.Runtime;
 @Runtime(CRuntime.class)
 public class HunspellLibrary {
 	static {
-		BridJ.register();
+		BridJ.register(HunspellLibrary.class);
 	}
 
 	public static final int MAXWORDUTF8LEN = 256;


### PR DESCRIPTION
BridJ.register() tries to guess the ClassLoader instance. In OSGi it does not find the correct one, as it depends on each class.